### PR TITLE
actions: Build Go Binaries for linux

### DIFF
--- a/.github/workflows/Build Go Binaries for linux.yml
+++ b/.github/workflows/Build Go Binaries for linux.yml
@@ -1,0 +1,93 @@
+name: Build Go Binaries for linux
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release Tag (e.g., 0.1.0)'
+        required: true
+        default: '0.1.0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+          - arch: 386
+            filename: i386
+          - arch: arm
+            goarm: 5
+          - arch: arm
+            goarm: 6
+          - arch: arm
+            goarm: 7
+          - arch: arm64
+          - arch: mips
+          - arch: mipsle
+          - arch: mips64
+          - arch: mips64le
+
+    name: Build for ${{ matrix.arch }}${{ matrix.goarm && format(' (GOARM={0})', matrix.goarm) || '' }}
+
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
+
+      - name: Install UPX
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y upx
+
+      - name: Build Binary
+        run: |
+          mkdir -p build
+
+          if [[ "${{ matrix.arch }}" == "386" ]]; then
+            OUTPUT_FILE="geoview-linux-i386"
+          elif [[ "${{ matrix.arch }}" == "arm" ]]; then
+            OUTPUT_FILE="geoview-linux-armv${{ matrix.goarm }}"
+            export GOARM=${{ matrix.goarm }}
+          else
+            OUTPUT_FILE="geoview-linux-${{ matrix.arch }}"
+          fi
+
+          export CGO_ENABLED=0
+          GOOS=linux GOARCH=${{ matrix.arch }} GOARM=$GOARM \
+          go build -ldflags="-s -w" -o build/$OUTPUT_FILE main.go
+
+          if [[ "${{ matrix.arch }}" != "mips64" && "${{ matrix.arch }}" != "mips64le" ]]; then
+            upx build/$OUTPUT_FILE
+          else
+            echo "Skipping UPX compression for $OUTPUT_FILE (not supported)"
+          fi
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+          files: build/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  cleanup:
+    name: Cleanup Old Workflow Runs
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@main
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 1
+          keep_minimum_runs: 1


### PR DESCRIPTION
我打算在pw的组件更新上添加geoview的更新，所以弄了actions编译常用架构编译脚本，已经在我的仓库测试正常了，运行前输入版本号就可以自动设置版本标签并编译常用的的二进制文件，同时用upx进行压缩（除了mips64和mips64le，upx不支持），并上传到releases，过程不到1分钟。
考虑到你这边是geoview的官方库，所以我想还是在你这边发行版本好些。到时pw那边geoview的更新api我直接调用你仓库的releases。
你意下如何？如果没问题的话可直接合并这个pr，测试重新发布0.1.6看看（不用删除旧的标签，以免makefile失效）。
@snowie2000 