### PR TITLE
actions: build add riscv64 arch

### DIFF
--- a/.github/workflows/Build Go Binaries for linux.yml
+++ b/.github/workflows/Build Go Binaries for linux.yml
@@ -30,6 +30,7 @@ jobs:
           - arch: mipsle
           - arch: mips64
           - arch: mips64le
+          - arch: riscv64
 
     name: Build for ${{ matrix.arch }}${{ matrix.goarm && format(' (GOARM={0})', matrix.goarm) || '' }}
 
@@ -64,7 +65,7 @@ jobs:
           GOOS=linux GOARCH=${{ matrix.arch }} GOARM=$GOARM \
           go build -ldflags="-s -w" -o build/$OUTPUT_FILE main.go
 
-          if [[ "${{ matrix.arch }}" != "mips64" && "${{ matrix.arch }}" != "mips64le" ]]; then
+          if [[ "${{ matrix.arch }}" != "mips64" && "${{ matrix.arch }}" != "mips64le" && "${{ matrix.arch }}" != "riscv64" ]]; then
             upx build/$OUTPUT_FILE
           else
             echo "Skipping UPX compression for $OUTPUT_FILE (not supported)"


### PR DESCRIPTION
添加了生成 riscv64 架构二进制文件的代码，麻烦合并后重新运行一次让他生成 riscv64 的文件。